### PR TITLE
collections pass on client to items

### DIFF
--- a/lib/skydrive/collection.rb
+++ b/lib/skydrive/collection.rb
@@ -20,7 +20,7 @@ module Skydrive
       @items = []
       @data.each do |object_data|
         if object_data["type"]
-          @items << "Skydrive::#{object_data["type"].capitalize}".constantize.new(self, object_data)
+          @items << "Skydrive::#{object_data["type"].capitalize}".constantize.new(client, object_data)
         elsif object_data["id"].match /^comment\..+/
           @items << Skydrive::Comment.new(client, object_data)
         end


### PR DESCRIPTION
Collections should pass on the client to new objects created by Skydrive::Collection#items

Otherwise you will get an error in this situation:
```
# Get the skydrive root folder
folder = client.my_skydrive

# Get a subfolder
sub_folder = folder.files.items.find { |item| item.kind_of? Skydrive::Folder }

# Error when getting items from subfolder
subfolder.files.items
#=> NoMethodError: undefined method `get' for #<Skydrive::Collection:0x00000003886c58>
	from /home/john/.rvm/gems/ruby-2.1.3@john-hager-info/gems/skydrive-1.0.0/lib/skydrive/folder.rb:13:in `files'

```

Another way to fix the problem would be to delegate all client methods in collection to the client, but this seems unnecessary. (Unless there was a specific reason for passing the collection as the client?)
