### PR TITLE
modified client put to use no content-type header

### DIFF
--- a/lib/skydrive/client.rb
+++ b/lib/skydrive/client.rb
@@ -42,7 +42,7 @@ module Skydrive
     # @param [String] url the url to put
     # @param [Hash] options Additonal options to be passed
     def put url, body=nil, options={}
-      response = filtered_response(self.class.put(url, {:body => body, :query => options}))
+      response = filtered_response(self.class.put(url, { :body => body, :query => options, headers: { 'content-type' => ''} }))
     end
 
     # Get the acting user


### PR DESCRIPTION
According to the REST API documentation (https://msdn.microsoft.com/en-us/library/dn631831.aspx) in put methods, the content-type header should be blank).

Otherwise when sending a put with a body in the request of a file, the content-type is given and the response is a 415 (Invalid Media Type)