### PR TITLE
return skydrive objects if a 201 created response is returned

### DIFF
--- a/lib/skydrive/client.rb
+++ b/lib/skydrive/client.rb
@@ -74,7 +74,7 @@ module Skydrive
       raise Skydrive::Error.new({"code" => "no_response_received", "message" => "Request didn't make through or response not received"}) unless response
       if response.success?
         filtered_response = response.parsed_response
-        if response.response.code == "200"
+        if response.response.code =~ /(201|200)/
           raise Skydrive::Error.new(filtered_response["error"]) if filtered_response["error"]
           if filtered_response["data"]
             return Skydrive::Collection.new(self, filtered_response["data"])            


### PR DESCRIPTION
This is more of a feature.

If you create an object, you should receive an object back when the API returns a 201 code.

The API sends back data, it seems like a good idea to make this available to the user.  It's more useful than just getting true.