### PR TITLE
Restoring default usage of content-type for PUT.

### DIFF
--- a/lib/skydrive/client.rb
+++ b/lib/skydrive/client.rb
@@ -42,7 +42,7 @@ module Skydrive
     # @param [String] url the url to put
     # @param [Hash] options Additonal options to be passed
     def put url, body=nil, options={}
-      response = filtered_response(self.class.put(url, { :body => body, :query => options, headers: { 'content-type' => ''} }))
+      response = filtered_response(self.class.put(url, { :body => body, :query => options }))
     end
 
     # Get the acting user
@@ -77,7 +77,7 @@ module Skydrive
         if response.response.code =~ /(201|200)/
           raise Skydrive::Error.new(filtered_response["error"]) if filtered_response["error"]
           if filtered_response["data"]
-            return Skydrive::Collection.new(self, filtered_response["data"])            
+            return Skydrive::Collection.new(self, filtered_response["data"])
           elsif filtered_response["id"] && (filtered_response["id"].match /^comment\..+/)
             return Skydrive::Comment.new(self, filtered_response)
           elsif filtered_response["id"] && (filtered_response["id"].match /^file\..+/)


### PR DESCRIPTION
Using an empty string results in errors from the API when attempting to rename
a file using the PUT method. Defaults to `application/json`.
